### PR TITLE
Generate JaCoCo and unit test HTML reports in site directory

### DIFF
--- a/.github/workflows/maven-build-check.yml
+++ b/.github/workflows/maven-build-check.yml
@@ -52,10 +52,6 @@ jobs:
         SPRING_PROFILES_ACTIVE: test
         DB_PASSWORD: postgres
 
-    # Генерація звітів
-    - name: Генерація звітів
-      run: mvn site
-
     # Завантаження звітів про результати тестування
     - name: завантаження звітів
       if: always()

--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@
 # Кроки для запуску програми і відкриття web-interface в Windows PowerShell
 1. Встановіть локально PostgreSQL, Maven та Java.
 2. Створіть базу даних college_db.
-3. Відкрийте PowerShell і виконайте неступну команду для відображення символів в UTF-8 кодуванні: `chcp 65001`
-4. Запустіть програму в PowerShell за допомогою команди: `mvn -DDB_PASSWORD="пароль-до-бази-даних" exec:java -D"exec.mainClass=com.college.MainApp"`.
-5. Відкрийте web-interface в браузері за адресою localhost:8080
+3. Відкрийте PowerShell і виконайте неступну команду для відображення символів в UTF-8 кодуванні: `chcp 65001`.
+4. Зберіть проект за допомогою команди: `mvn clean install`.
+5. Запустіть програму за допомогою команди: `mvn -DDB_PASSWORD="пароль-до-бази-даних" exec:java -D"exec.mainClass=com.college.MainApp"`.
+6. Відкрийте web-interface в браузері за адресою localhost:8080
 ```
 
 ## Публікація артефактів

--- a/pom.xml
+++ b/pom.xml
@@ -80,27 +80,6 @@
     </dependency>
   </dependencies>
   
-  <!-- Налаштування звітів -->
-  <reporting>
-    <plugins>
-      <!-- Звіти про тести -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-report-plugin</artifactId>
-        <version>3.2.5</version>
-      </plugin>
-
-    </plugins>
-  </reporting>
-
-  <distributionManagement>
-    <repository>
-      <id>github</id>
-      <name>GitHub Packages</name>
-      <url>https://maven.pkg.github.com/chdbc-samples/college-schedule-app</url>
-    </repository>
-  </distributionManagement>
-
   <!-- Налаштування збірки -->
   <build>
     <plugins>
@@ -114,18 +93,40 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
+        <!-- Keep existing configuration -->
         <configuration>
           <argLine>${surefireArgLine}</argLine>
           <includes>
             <include>**/*Test.java</include>
             <include>**/*IntegrationTest.java</include>
           </includes>
-          <reportFormat>html</reportFormat>
+          <!-- XML/TXT reports are generated here by default -->
           <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
         </configuration>
       </plugin>
-      
 
+      <!-- Generate Surefire HTML report during the test phase -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-report-plugin</artifactId>
+        <version>3.2.5</version> <!-- Use the same version as in reporting section -->
+        <executions>
+          <execution>
+            <id>generate-surefire-report</id>
+            <phase>test</phase>
+            <goals>
+              <goal>report-only</goal> <!-- Use report-only to generate from existing test results -->
+            </goals>
+            <configuration>
+              <!-- Output the HTML report to the site directory -->
+              <outputDirectory>${project.reporting.outputDirectory}</outputDirectory>
+              <reportsDirectories>
+                <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
+              </reportsDirectories>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
 
       <!-- Налаштування плагіна Site -->
       <plugin>
@@ -186,15 +187,16 @@
             </configuration>
           </execution>
           
-          <!-- Єдиний звіт про тести -->
+          <!-- Єдиний звіт про тести (already bound to test phase and outputs to site/jacoco) -->
           <execution>
             <id>default-report</id>
-            <phase>test</phase>
+            <phase>test</phase> <!-- This ensures report runs during 'mvn test' -->
             <goals>
               <goal>report</goal>
             </goals>
             <configuration>
               <dataFile>${project.build.directory}/jacoco.exec</dataFile>
+              <!-- Output directory is already target/site/jacoco -->
               <outputDirectory>${project.reporting.outputDirectory}/jacoco</outputDirectory>
               <title>${project.name} - Code Coverage Report</title>
               <footer>Code Coverage Report for ${project.name} ${project.version}</footer>
@@ -267,4 +269,31 @@
       </testResource>
     </testResources>
   </build>
+  
+  <!-- Налаштування звітів (This section is used by 'mvn site') -->
+  <reporting>
+      <plugins>
+          <!-- Звіти про тести (Surefire report config for 'mvn site') -->
+          <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-surefire-report-plugin</artifactId>
+              <version>3.2.5</version>
+              <!-- Optional: Add configuration here if needed specifically for 'mvn site' -->
+          </plugin>
+          <!-- Optional: Add JaCoCo report config here if you also want it during 'mvn site' -->
+          <!--
+          <plugin>
+              <groupId>org.jacoco</groupId>
+              <artifactId>jacoco-maven-plugin</artifactId>
+              <reportSets>
+                  <reportSet>
+                      <reports>
+                          <report>report</report>
+                      </reports>
+                  </reportSet>
+              </reportSets>
+          </plugin>
+          -->
+      </plugins>
+  </reporting>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,14 @@
     </dependency>
   </dependencies>
   
+  <distributionManagement>
+    <repository>
+      <id>github</id>
+      <name>GitHub Packages</name>
+      <url>https://maven.pkg.github.com/chdbc-samples/college-schedule-app</url>
+    </repository>
+  </distributionManagement>
+
   <!-- Налаштування збірки -->
   <build>
     <plugins>


### PR DESCRIPTION
### What I did
This pull request refactors the Maven build configuration by reorganizing the reporting and plugin setup to optimize test report generation and simplify the workflow. The most significant changes include moving the Surefire report generation to the test phase, reintroducing the `reporting` section for `mvn site`, and removing redundant configurations.

### Changes to Maven Build Configuration:

* **Reorganization of Surefire Report Generation**:
  - Moved the `maven-surefire-report-plugin` configuration to the test phase, enabling HTML reports to be generated during `mvn test` using existing test results.
  - Updated the JaCoCo report execution to clarify its binding to the test phase and its output directory.

* **Reintroduction of `reporting` Section**:
  - Reintroduced the `reporting` section in `pom.xml` for generating reports during the `mvn site` phase, including configurations for the Surefire report plugin.

### Workflow Adjustments:

* **Removal of Redundant Report Generation in CI**:
  - Removed the `mvn site` step from the GitHub Actions workflow to streamline the CI process, as reports are now generated during the test phase.

These changes improve the clarity and maintainability of the Maven configuration while aligning the reporting process with best practices.

### Related issue
#17

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```