### PR TITLE
Fix file extension for PostgreSQL deployment 

### DIFF
--- a/.github/workflows/deploy-to-azure-aks.yml
+++ b/.github/workflows/deploy-to-azure-aks.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Розгортання PostgreSQL
         run: |
           echo "Deploying PostgreSQL..."
-          kubectl apply -f deploy/k8s-manifests/postgres-deployment.yaml
+          kubectl apply -f deploy/k8s-manifests/postgres-deployment.yml
           
           # Чекаємо, поки PostgreSQL буде готовий
           echo "Waiting for PostgreSQL to be ready..."


### PR DESCRIPTION
### What I did
This pull request includes a minor change to the `.github/workflows/deploy-to-azure-aks.yml` file. The change updates the file extension for the PostgreSQL deployment manifest from `.yaml` to `.yml` to ensure consistency and compatibility.

* [`.github/workflows/deploy-to-azure-aks.yml`](diffhunk://#diff-f36ed965a5a979e656e178e9da4276391a4193b3de2a347e9ef35c2cb8063065L68-R68): Changed the extension of the PostgreSQL deployment manifest from `.yaml` to `.yml`.

Workflow ran successfully: https://github.com/chdbc-samples/college-schedule-app/actions/runs/15299216391

### Related issue
#6 

### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog.
It must be placed inside the below triple backticks section:
-->
```markdown changelog

```